### PR TITLE
Allow for a kind of equality for decoders

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,8 @@
     "purescript-sequences": "^1.0.0",
     "purescript-sets": "^3.0.0",
     "purescript-strings": "^3.0.0",
-    "purescript-io": "^5.0.0"
+    "purescript-io": "^5.0.0",
+    "purescript-leibniz": "^4.1.0"
   },
   "devDependencies": {
     "purescript-test-unit": "^13.0.0",

--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,8 @@
     "purescript-sets": "^3.0.0",
     "purescript-strings": "^3.0.0",
     "purescript-io": "^5.0.0",
-    "purescript-leibniz": "^4.1.0"
+    "purescript-leibniz": "^4.1.0",
+    "purescript-unsafe-reference": "^2.0.0"
   },
   "devDependencies": {
     "purescript-test-unit": "^13.0.0",

--- a/src/Elm/Json/Decode.purs
+++ b/src/Elm/Json/Decode.purs
@@ -29,7 +29,7 @@ module Elm.Json.Decode
     ) where
 
 
-import Control.Alt (class Alt, alt, (<|>))
+import Control.Alt (class Alt, (<|>))
 import Control.Apply (lift2, lift3, lift4, lift5)
 import Control.Bind ((>=>))
 import Control.Monad.Except (runExcept)
@@ -39,7 +39,7 @@ import Data.Array as Array
 import Data.Coyoneda (Coyoneda, coyoneda, unCoyoneda)
 import Data.Either (Either(..))
 import Data.Exists (Exists, mkExists, runExists)
-import Data.Foldable (class Foldable, foldl, foldMap)
+import Data.Foldable (class Foldable, foldMap)
 import Data.Foldable (oneOf) as Virtual
 import Data.Foreign (Foreign, ForeignError(..), F, readArray, readString, readBoolean, readNumber, readInt, isNull, isUndefined, typeOf)
 import Data.Foreign as DF
@@ -881,21 +881,24 @@ value :: Decoder Value
 value = valueT
 
 
+fromResult :: ∀ a. Result String a -> Decoder a
+fromResult =
+    case _ of
+        Ok ok ->
+            succeed_ ok
+
+        Err err ->
+            fail err
+
+
 -- | Create a custom decoder that may do some fancy computation.
+-- |
+-- | `equalDecoders` will consider the resulting decoders equal if the input
+-- | decoders are equal, and the provided functions in each case are
+-- | referentially equal.
 customDecoder :: ∀ a b. Decoder a -> (a -> Result String b) -> Decoder b
 customDecoder decoder func =
-    -- This should work, but it may end up not playing well with `equalDecoder`
-    -- ... I might have to capture the decoder and func in the DSL. Because the
-    -- function I'm captured in the `Bind` is a lmbda, constructed fresh each
-    -- time, so it won't be referentially equal, even if it's the same func.
-    decoder >>=
-        \a ->
-            case func a of
-                Ok ok ->
-                    succeed_ ok
-
-                Err err ->
-                    fail err
+    func <$> decoder >>= fromResult
 
 
 -- | Sometimes you have JSON with recursive structure, like nested comments.
@@ -981,6 +984,8 @@ succeed_ = Succeed Nothing
 -- |           ]
 -- |
 -- | This function was removed in Elm 0.18.
+-- |
+-- | Does not work with `equalDecoders` yet, but this is probably fixable.
 tuple1 :: ∀ a value. (a -> value) -> Decoder a -> Decoder value
 tuple1 func d0 = do
     void $ arrayOfLengthT 1
@@ -1003,6 +1008,8 @@ tuple1 func d0 = do
 -- |     type Name = { first :: String, last :: String }
 -- |
 -- | This function was removed in Elm 0.18.
+-- |
+-- | Does not work with `equalDecoders` yet, but this is probably fixable.
 tuple2 :: ∀ a b value. (a -> b -> value) -> Decoder a -> Decoder b -> Decoder value
 tuple2 func d0 d1 = do
     void $ arrayOfLengthT 2
@@ -1016,6 +1023,8 @@ tuple2 func d0 d1 = do
 -- | Handle an array with exactly three elements.
 -- |
 -- | This function was removed in Elm 0.18.
+-- |
+-- | Does not work with `equalDecoders` yet, but this is probably fixable.
 tuple3 :: ∀ a b c value. (a -> b -> c -> value) -> Decoder a -> Decoder b -> Decoder c -> Decoder value
 tuple3 func d0 d1 d2 = do
     void $ arrayOfLengthT 3
@@ -1028,6 +1037,8 @@ tuple3 func d0 d1 d2 = do
 
 
 -- | This function was removed in Elm 0.18.
+-- |
+-- | Does not work with `equalDecoders` yet, but this is probably fixable.
 tuple4 :: ∀ a b c d value. (a -> b -> c -> d -> value) -> Decoder a -> Decoder b -> Decoder c -> Decoder d -> Decoder value
 tuple4 func d0 d1 d2 d3 = do
     void $ arrayOfLengthT 4
@@ -1041,6 +1052,8 @@ tuple4 func d0 d1 d2 d3 = do
 
 
 -- | This function was removed in Elm 0.18.
+-- |
+-- | Does not work with `equalDecoders` yet, but this is probably fixable.
 tuple5 :: ∀ a b c d e value. (a -> b -> c -> d -> e -> value) -> Decoder a -> Decoder b -> Decoder c -> Decoder d -> Decoder e -> Decoder value
 tuple5 func d0 d1 d2 d3 d4 = do
     void $ arrayOfLengthT 5
@@ -1055,6 +1068,8 @@ tuple5 func d0 d1 d2 d3 d4 = do
 
 
 -- | This function was removed in Elm 0.18.
+-- |
+-- | Does not work with `equalDecoders` yet, but this is probably fixable.
 tuple6 :: ∀ a b c d e f value. (a -> b -> c -> d -> e -> f -> value) -> Decoder a -> Decoder b -> Decoder c -> Decoder d -> Decoder e -> Decoder f -> Decoder value
 tuple6 func d0 d1 d2 d3 d4 d5 = do
     void $ arrayOfLengthT 6
@@ -1070,6 +1085,8 @@ tuple6 func d0 d1 d2 d3 d4 d5 = do
 
 
 -- | This function was removed in Elm 0.18.
+-- |
+-- | Does not work with `equalDecoders` yet, but this is probably fixable.
 tuple7 :: ∀ a b c d e f g value. (a -> b -> c -> d -> e -> f -> g -> value) -> Decoder a -> Decoder b -> Decoder c -> Decoder d -> Decoder e -> Decoder f -> Decoder g -> Decoder value
 tuple7 func d0 d1 d2 d3 d4 d5 d6 = do
     void $ arrayOfLengthT 7
@@ -1086,6 +1103,8 @@ tuple7 func d0 d1 d2 d3 d4 d5 d6 = do
 
 
 -- | This function was removed in Elm 0.18.
+-- |
+-- | Does not work with `equalDecoders` yet, but this is probably fixable.
 tuple8 :: ∀ a b c d e f g h value. (a -> b -> c -> d -> e -> f -> g -> h -> value) -> Decoder a -> Decoder b -> Decoder c -> Decoder d -> Decoder e -> Decoder f -> Decoder g -> Decoder h -> Decoder value
 tuple8 func d0 d1 d2 d3 d4 d5 d6 d7 = do
     void $ arrayOfLengthT 8

--- a/src/Elm/Json/Decode.purs
+++ b/src/Elm/Json/Decode.purs
@@ -1,16 +1,30 @@
 
--- | Turn JSON values into Elm values. Definitely check out this [intro to
--- | JSON decoders][guide] to get a feel for how this library works!
+-- | > Turn JSON values into Elm values. Definitely check out this [intro to
+-- | > JSON decoders][guide] to get a feel for how this library works!
 -- |
 -- | [guide]: https://guide.elm-lang.org/interop/json.html
 -- |
 -- | Elm's `Json.Decode` doesn't seem to be quite like any existing Purescript
 -- | package, so I've re-implemented it, using parts of purescript-foreign as
 -- | a base. For other approaches to decoding JSON in Purescript, you could see
--- | purescript-foreign, and the purescript-argonaut-* packages.
+-- | purescript-foreign, and the purescript-argonaut packages. It would
+-- | probasbly be a good idea to extend this code by allowing for integration
+-- | with purescript-argonaut as an option in addition to purescript-foreign.
+-- |
+-- | The key difference between Elm's approach to decoders and what
+-- | purescript-foreign or purescript-argonaut do is that Elm needs to be
+-- | able to make some kind of decision about the equality of two decoders, in
+-- | order for the virtual DOM to decide whether a listener can be kept or
+-- | needs to be removed and re-added.  This drives the design of this module
+-- | towards a kind of DSL that allows `equalDecoders` to do a little bit more
+-- | than just compare decoders for referential equality, at least in some cases.
+-- | I've documented how the various functions in this module interact with
+-- | `equalDecoders`.
 -- |
 -- | Note that (so far) we're not trying to preserve all the nice error messages
--- | that Elm gives ... we could do a better job of that.
+-- | that Elm gives ... we could do a better job of that. (Elm uses a different
+-- | approach to JSON errors in Elm 0.19, so I may well wait for that in order
+-- | to do something nicer with errors here).
 
 module Elm.Json.Decode
     ( module Virtual
@@ -51,7 +65,7 @@ import Data.Tuple (Tuple(..))
 import Data.Unfoldable (class Unfoldable, unfoldr)
 import Elm.Apply (andMap, map2, map3, map4, map5, map6, map7, map8) as Virtual
 import Elm.Apply (map6, map7, map8)
-import Elm.Array as ElmArray
+import Elm.Array as Elm.Array
 import Elm.Basics (Bool, Float)
 import Elm.Bind (andThen) as Virtual
 import Elm.Dict (Dict)
@@ -67,16 +81,69 @@ import Unsafe.Coerce (unsafeCoerce)
 import Unsafe.Reference (reallyUnsafeRefEq, unsafeRefEq)
 
 
--- | A value that knows how to decode JSON values.
+-- | > A value that knows how to decode JSON values.
+-- |
+-- | Here are some notes about the degree to which the instances preserve the
+-- | ability of `equalDecoders` to detect equality. See the docs for
+-- | `equalDecoders` for a more general explanation -- it can always detect the
+-- | equality of decoders that are the very same decoder (i.e. with the same
+-- | reference), so the question is how well it can deteect the equality of
+-- | decoders that are separately constructed (not the very same reference).
+-- |
+-- | The `Functor` instance preserves equality detection so long as the
+-- | function you supply to `map` is referentially equal in each case (since we
+-- | can't check functions for equality except via referential equality). So,
+-- | it is better to `map` with a function that you've pulled out to the
+-- | top-level, with a stable reference, rather than a function defined inline
+-- | as a lambda. Of course, the decoder you supply to `map` must also itself
+-- | have preserved equality detection.
+-- |
+-- | The `Alt` instance preserves equality detection. Of course, the decoders
+-- | you supply to `alt` or `<|>` must themselves have been constructed in a
+-- | way that preserves equality detection.
+-- |
+-- | The `Plus` instance preserves equality detection. (I.e. one `empty` decoder
+-- | will be equal to another, and should interact with `<|>` and `oneOf` in
+-- | the correct ways).
+-- |
+-- | The `Apply` instance preserves equality detection if at least one of the
+-- | arguments is referentially equal in each case. This isn't entirely optimal
+-- | for *repeated* applications of `<*>`, which is how `map2`, `map3`, `map4`
+-- | etc. are implemented (and are indirectly a prominent idiom in Elm code,
+-- | such as in `Json.Decode.Pipeline`).  The problem is that each of the
+-- | decoders you supply must be referentially equal in each case, which would
+-- | be awkward to arrange. The equivalent functions in Elm can do a better job
+-- | of detecting equality in this case, so there is some room for improvement
+-- | here.
+-- |
+-- | The `Applicative` instance isn't able to insist on an `Eq` constraint for
+-- | the value you supply to `pure`. Thus, `equalDecoders` will be limited to
+-- | using referential equality on values you supply to `pure`. So, it will be
+-- | preferable to use `succeed` directly where you can.
+-- |
+-- | The `Bind` instance preserves equality detection if the supplied function
+-- | is referentially equal in each case. This is a little awkward for
+-- | do-notation, or an `|> andThen` pipeline (the roughly-equivalent Elm
+-- | idiom), since in those cases the functions will typically be defined
+-- | inline, and thus not with a stable reference. However, if you can stick to
+-- | functions with stable references, rather than defined inline, (>>=) and
+-- | `andThen` will preserve equality.
 --
 -- We collect some evidence about what the `a` is, in cases where it's not
--- fully polymorphic.
+-- fully polymorphic. (We should do something like this with `RunArray`, but
+-- I'm not entirely sure how to do it when the `a` is still partly
+-- polymorphic).
 --
 -- The `Run` constructor is probably an example of something more general that
 -- I'm not seeing yet.
 --
 -- This little DSL could probably be sipmlified a bit ...  ideally, it should
--- consist of irreducible things.
+-- consist of irreducible things. It's also possible that we should be using a
+-- "free monad" here ... this is reminiscent of a free monad, but I couldn't
+-- quite figure out how to literally use one and still get the Elm API. (E.g.
+-- it seemed that the `Decoder` would need an extra type variable, which
+-- perhaps could be elimimated in some way, but I didn't get far enough down
+-- that road to figure it out).
 data Decoder a
     = Ap (ApplyCoyoneda Decoder a)
     | Array (a ~ Array Foreign)
@@ -98,8 +165,7 @@ data Decoder a
 
 
 -- Somewhat sinilar to the `Exists` strategy, but squashing and unsquashing a
--- type constructor. I have a feeling that I'm missing something simple here
--- ...  I suppose I'm working around the lack of polykinds?
+-- type constructor. I have a feeling that I'm missing something simple here.
 foreign import data ExistsRunArray :: Type -> Type
 
 mkExistsRunArray :: ∀ t a. RunArray t a -> ExistsRunArray (t a)
@@ -109,7 +175,9 @@ runExistsRunArray :: ∀ r b. (∀ t a. RunArray t a -> r) -> ExistsRunArray b -
 runExistsRunArray = unsafeCoerce
 
 -- I probably also need to collect some Leibniz-like proof for the type (t a),
--- but it's not clear to me how to arrange that.
+-- but it's not clear to me how to arrange that. That is, I need to squash the
+-- type to work with `Decoder`, but I'd ideally like to recover some evidence
+-- of it inside `decodeValue` and `equalDecoders`.
 type RunArray t a =
     { input :: Decoder (Array Foreign)
     , tagger :: Decoder a
@@ -120,7 +188,8 @@ type RunArray t a =
 -- The Foreign module uses `Except` to pass errors around, whereas we need
 -- `Result String a`.
 --
--- We should render the err case a little more nicely.
+-- We should render the err case a little more nicely -- but Elm 0.19 will have
+-- some improvements there, so we may as well wait for that.
 toResult :: ∀ a. F a -> Result String a
 toResult f =
     case runExcept f of
@@ -128,8 +197,8 @@ toResult f =
         Left err -> Err (show err)
 
 
--- | Run a `Decoder` on some JSON `Value`. You can send these JSON values
--- | through ports, so that is probably the main time you would use this function.
+-- | > Run a `Decoder` on some JSON `Value`. You can send these JSON values
+-- | > through ports, so that is probably the main time you would use this function.
 decodeValue :: ∀ a. Decoder a -> Value -> Result String a
 decodeValue =
     -- This gets called recursively without tail-calls, so it will use stack
@@ -175,7 +244,10 @@ decodeValue =
                     )
 
         Empty ->
-            const $ Err "empty decoder"
+            -- This case exists to make the `Plus` instance work ... in the
+            -- ordinary course, we wouldn't expect to get here, but we'll just
+            -- fail if we do.
+            const $ Err "Reached an empty decoder"
 
         Fail err ->
             const $ Err err
@@ -233,6 +305,7 @@ decodeValue =
                     decoded <-
                         decodeValue run.input val
                             >>= traverse (decodeValue run.tagger)
+
                     -- Ideally, I should collect some Leibniz-like evidence
                     -- I can use instead of the unsafeCoerce ...
                     pure $ unsafeCoerce $
@@ -249,14 +322,122 @@ decodeValue =
 
 
 -- | For cases where we have a witness that the two decoders are the same type.
+-- | Ideally, I should formalize the witness and provide it here, to make this
+-- | more foolproof.
 unsafeCoerceDecoder :: ∀ a b. Decoder a -> Decoder b
 unsafeCoerceDecoder = unsafeCoerce
 
 
--- | Tries to compare two decoders for equality. Subject to false negatives,
--- | but positives should be reliatble.
+-- | `equalDecoders` attempts to compare two decoders for equality. It is
+-- | subject to false negatives, but positives should be reliable. (For this
+-- | reason, we don't provide an `Eq` instance for `Decoder` ... this is a
+-- | function that has a specialized use, rather than being a fully reliable
+-- | test for equality).
 -- |
--- | Add some notes about which cases produce false negatives.
+-- | This is roughly equivalent to a function that Elm uses internally (not
+-- | exposed in Elm) as part of the virtual DOM, to decide whether a listener
+-- | must be removed and re-applied (because it uses a different decoder than
+-- | the previously applied listener). So, false negatives are an efficiency
+-- | issue (as listeners will be removed and re-applied unnecessarily), while
+-- | false positives would be a more serious problem (and should not occur).
+-- |
+-- | I have documented, for each function in the module, how well it preserves
+-- | the ability of `equalDecoders` to detect equality. The cases fall roughly
+-- | into these categories. (Elm's behaviour with respect to detecting equality
+-- | is roughly similar, I believe).
+-- |
+-- | ### The very same decoder
+-- |
+-- | If two decoders are the very same thing (i.e. referentially equal), then
+-- | `equalDecoders` will reliably detect that. So, if your `view` code
+-- | references a decoder by its top=level name, then `equalDecoders` will
+-- | detect that the decoder is equal to itself, on the next round. The decoder
+-- | may have been constructed in whatever complex way is necessary, but if you
+-- | refer to it via its top-level name (not a function call), then
+-- | `equalDecoders` will work well with it. So, in cases where it is possible
+-- | to define your decoder at the top-level, that is handy.
+-- |
+-- | So, if you define a decoder like this:
+-- |
+-- |     decodePerson :: Decoder Person
+-- |     decodePerson =
+-- |        ...
+-- |
+-- | ... that is, as a value, without arguments, then it doesn't matter what
+-- | you do in the `...` to construct the decoder ... `equalDecoders` will be
+-- | able to detect that `decodePerson` is equal to `decodePerson`.
+-- |
+-- | For a decoder to take advantage of this, it must be defined without taking
+-- | arguments, and must be defined at the top-level (i.e. not inside a `let`
+-- | expression). Otherwise, the decoder won't have a stable reference. It may
+-- | still compare successfully with `equalDecoders`, but that will depend on
+-- | exactly how it is constructed. If the decoder has a stable reference, then
+-- | it doesn't matter how it was constructed.
+-- |
+-- | ### Not the very same decoder
+-- |
+-- | If two decoders are not the very same thing, then whether `equalDecoders`
+-- | can successfully detect equality depends on how they were constructed and
+-- | combined. I've documented the effect of each function in this module on
+-- | the detection of equality, but the general rules are as follows:
+-- |
+-- | - The equality of primitive decoders can always be detected
+-- |
+-- |   e.g. `float`, `int`, `bool`, `string`, `value`
+-- |
+-- | - If you have to supply an argument that is a function, then we can only
+-- |   detect equality if you supply a function that is referentially equal in
+-- |   each case. So, it's better to avoid defining functions "inline" as a
+-- |   lambda when creating a decoder. Instead, try to pull the functions out
+-- |   to the top-level where you can, so they will have stable references for
+-- |   the purpose of testing referential equality.
+-- |
+-- |   e.g. `map`, `andThen`, `bind`, `fromForeign`, `customDecoder`, `lazy`
+-- |
+-- |   Note that for `bind`, this means that we'll have a limited ability to
+-- |   detect the equality of decoders defined using `do` notation (or an `|>
+-- |   andThen` pipeline, in the equivalent Elm idiom). Since the repeated
+-- |   "binds" are defined inline, they won't have stable references. However,
+-- |   if you can pull all but the first `bind` out into a stable reference,
+-- |   then a single `>>=` (or `andThen`) which refers to the stable reference
+-- |   will preserve equality.
+-- |
+-- | - If you have to supply other decoders as arguments, then generally we
+-- |   preserve equality detection. That is, the resulting decoder will generally
+-- |   work as well with `equalDecoders` as the decoders you supply.
+-- |
+-- |   e.g. `alt`, `<|>`, `oneOf`, `field`, `at`, `index`, `field`, `list`, `array`,
+-- |        `unfoldable`, `nullable`, `maybe`
+-- |
+-- |   However, there are a few exceptions, where at least one of the supplied
+-- |   decoders must be referentially equal in each case. This mainly affects
+-- |   the `Apply` instance, so the `<*>` operator and the `andMap` function.
+-- |
+-- |   Because of the way `map2`, `map3` etc. are implemented, this leads to an
+-- |   even more undesirable behaviour for them -- all of the decoders you
+-- |   supply must be referentially equal in each case. I believe Elm does
+-- |   better in preserving equality detection here, so it is an area where we
+-- |   have room for improvement.
+-- |
+-- | - If you supply values as an argument, then `equalDecoders` works best if
+-- |   you use functions that require an `Eq` instance. In those cases, we can
+-- |   use the `Eq` instance to compare the values when detecting the equality
+-- |   of decoders. Otherwise, we have to fall back on referential equality.
+-- |   So, prefer `succeed` and `null` to `succeed_` and `null_`.
+-- |
+-- |   One way in which this is a little awkward is that a "bare" record type
+-- |   cannot have an `Eq` instance -- you will need to make a `newtype` for
+-- |   it. However, once you've done that, the compiler can often derive an
+-- |   `Eq` instance for you (along with providing various other
+-- |   newtype-related conveniences), so it is only a mild nuisance. (Elm
+-- |   instead has a magic `==` that works with bare record types, though not
+-- |   without its own difficulties -- there is no free lunch here).
+-- |
+-- | - There are some functions which currently destroy the ability to detect
+-- |   equality (unless you keep a stable reference to the result), but which
+-- |   should be fixable.
+-- |
+-- |   e.g. `keyValuePairs`, `dict`, and `tuple1` through `tuple8`
 equalDecoders :: ∀ a. Decoder a -> Decoder a -> Bool
 equalDecoders d1 d2 =
     unsafeRefEq d1 d2 || case d1, d2 of
@@ -265,9 +446,13 @@ equalDecoders d1 d2 =
             coyoRight # unApplyCoyoneda (\tagger2 decoder2 ->
                 -- In this case, we've got decoders on both sides, and we don't
                 -- know what type we're coming from. So, the best we can do (at
-                -- least for now) is check referntial equality of each side.
+                -- least for now) is check referential equality of each side.
                 -- If either side has referntial equality, then we know the
                 -- types match.
+                --
+                -- Perhaps there would be a way to collect evidence about what
+                -- type we're coming from, so that we could compare that
+                -- evidence to know whether they are the same type?
                 case reallyUnsafeRefEq tagger1 tagger2, reallyUnsafeRefEq decoder1 decoder2 of
                     true, true ->
                          -- If they are both referentially equal, then we're
@@ -402,8 +587,6 @@ equalDecoders d1 d2 =
 -- `Bind` instances as well. (There may well be a better way to do that, e.g. a
 -- free monad?)
 instance functorDecoder :: Functor Decoder where
-    -- | Works with `equalDecoders` so long as the supplied functions are
-    -- | referentially equal.
     map func decoder =
         -- We know what the answer will be up-front for certain mapping
         -- operations, so we don't need to defer all of them.
@@ -419,8 +602,6 @@ instance functorDecoder :: Functor Decoder where
 
 
 instance altDecoder :: Alt Decoder where
-    -- | Works with `equalDecoders`
-    --
     -- We can apply the `Plus` laws immediately (but we also consider them in
     -- `decodeValue` and `equalDecoders`, just in case).
     alt Empty b = b
@@ -448,17 +629,11 @@ unApplyCoyoneda f (ApplyCoyoneda e) = runExists (\(ApplyCoyonedaF k fi) -> f k f
 -- It's possible that this is unnecessary if I just used a free monad ...  that
 -- is, I might be able to get this for free.
 instance applyDecoder :: Apply Decoder where
-    -- | Works with `equalDecoders` only if at least one of the arguments is
-    -- | referentially equal to the other case.
     apply f g =
         Ap $ applyCoyoneda f g
 
 
 instance applicativeDecoder :: Applicative Decoder where
-    -- | Works with `equalDecoders` if the supplied values are referentially
-    -- | equal. If the supplied values have an `Eq` instance, consider using
-    -- | `succeed` instead of `pure`, since `equalDecoders` will then be able
-    -- | to use the `Eq` instance.
     pure = succeed_
 
 
@@ -515,12 +690,12 @@ valueT :: Decoder Value
 valueT = Value id
 
 
--- | Parse the given string into a JSON value and then run the `Decoder` on it.
--- | This will fail if the string is not well-formed JSON or if the `Decoder`
--- | fails for some reason.
+-- | > Parse the given string into a JSON value and then run the `Decoder` on it.
+-- | > This will fail if the string is not well-formed JSON or if the `Decoder`
+-- | > fails for some reason.
 -- |
--- |     decodeString int "4"     == Ok 4
--- |     decodeString int "1 + 2" == Err ...
+-- | >     decodeString int "4"     == Ok 4
+-- | >     decodeString int "1 + 2" == Err ...
 decodeString :: ∀ a. Decoder a -> String -> Result String a
 decodeString decoder str =
     toResult (parseJSON str) >>= decodeValue decoder
@@ -528,36 +703,36 @@ decodeString decoder str =
 
 -- OBJECTS
 
--- | Decode a nested JSON object, requiring certain fields.
--- |
--- |     json = """{ "person": { "name": "tom", "age": 42 } }"""
--- |
--- |     decodeString (at ["person", "name"] string) json  == Ok "tom"
--- |     decodeString (at ["person", "age" ] int   ) json  == Ok "42
--- |
--- | This is really just a shorthand for saying things like:
--- |
--- |     field "person" (field "name" string) == at ["person","name"] string
+-- | > Decode a nested JSON object, requiring certain fields.
+-- | >
+-- | >     json = """{ "person": { "name": "tom", "age": 42 } }"""
+-- | >
+-- | >     decodeString (at ["person", "name"] string) json  == Ok "tom"
+-- | >     decodeString (at ["person", "age" ] int   ) json  == Ok "42
+-- | >
+-- | > This is really just a shorthand for saying things like:
+-- | >
+-- | >     field "person" (field "name" string) == at ["person","name"] string
 -- |
 -- | Note that the signature is defined in terms of `Foldable` so that it will
 -- | work with `Array` or `List` (among others).
 -- |
--- | Works as you would expect with `equalDecoders`. Will also be considered
--- | equal with decoders constructed manually with nested fields, if the field
--- | names match.
+-- | Preserves equality for `equalDecoders`. The resulting decoder will also be
+-- | considered equal with decoders constructed manually with nested `field`
+-- | applications, if the field names match.
 at :: ∀ f a. (Foldable f) => f String -> Decoder a -> Decoder a
 at fields decoder =
     foldr field decoder fields
 
 
--- | Decode a JSON array, requiring a particular index.
--- |
--- |     json = """[ "alice", "bob", "chuck" ]"""
--- |
--- |     decodeString (index 0 string) json  == Ok "alice"
--- |     decodeString (index 1 string) json  == Ok "bob"
--- |     decodeString (index 2 string) json  == Ok "chuck"
--- |     decodeString (index 3 string) json  == Err ...
+-- | > Decode a JSON array, requiring a particular index.
+-- | >
+-- | >     json = """[ "alice", "bob", "chuck" ]"""
+-- | >
+-- | >     decodeString (index 0 string) json  == Ok "alice"
+-- | >     decodeString (index 1 string) json  == Ok "bob"
+-- | >     decodeString (index 2 string) json  == Ok "chuck"
+-- | >     decodeString (index 3 string) json  == Err ...
 -- |
 -- | This function was added in Elm 0.18.
 -- |
@@ -569,19 +744,19 @@ index :: ∀ a. Int -> Decoder a -> Decoder a
 index = Run <<< indexT
 
 
--- | Decode a JSON object, requiring a particular field.
--- |
--- |     decodeString (field "x" int) "{ \"x\": 3 }"            == Ok 3
--- |     decodeString (field "x" int) "{ \"x\": 3, \"y\": 4 }"  == Ok 3
--- |     decodeString (field "x" int) "{ \"x\": true }"         == Err ...
--- |     decodeString (field "x" int) "{ \"y\": 4 }"            == Err ...
--- |
--- |     decodeString (field "name" string) "{ \"name\": \"tom\" }" == Ok "tom"
--- |
--- | The object *can* have other fields. Lots of them! The only thing this decoder
--- | cares about is if `x` is present and that the value there is an `Int`.
--- |
--- | Check out [`map2`](#map2) to see how to decode multiple fields!
+-- | > Decode a JSON object, requiring a particular field.
+-- | >
+-- | >     decodeString (field "x" int) "{ \"x\": 3 }"            == Ok 3
+-- | >     decodeString (field "x" int) "{ \"x\": 3, \"y\": 4 }"  == Ok 3
+-- | >     decodeString (field "x" int) "{ \"x\": true }"         == Err ...
+-- | >     decodeString (field "x" int) "{ \"y\": 4 }"            == Err ...
+-- | >
+-- | >     decodeString (field "name" string) "{ \"name\": \"tom\" }" == Ok "tom"
+-- | >
+-- | > The object *can* have other fields. Lots of them! The only thing this decoder
+-- | > cares about is if `x` is present and that the value there is an `Int`.
+-- | >
+-- | > Check out [`map2`](#map2) to see how to decode multiple fields!
 -- |
 -- | `equalDecoders` will consider the resulting decoder equal to another
 -- | produced by this function if the field names are equal and the supplied
@@ -594,28 +769,28 @@ field = Run <<< fieldT
 infixl 4 field as :=
 
 
--- | Apply a function to a decoder.
--- |
--- |     object1 sqrt ("x" := float)
+-- | > Apply a function to a decoder.
+-- | >
+-- | >     object1 sqrt ("x" := float)
 -- |
 -- | Equivalent to Purescript's `map`.
 -- |
 -- | Removed in Elm 0.18, in favour of `map`.
 -- |
--- | Works with `equalDecoers` so long as the function supplied in one case is
+-- | Works with `equalDecoders` so long as the function supplied in one case is
 -- | referentially equal to the function supplied in the other.
 object1 :: ∀ a value. (a -> value) -> Decoder a -> Decoder value
 object1 = map
 
 
--- | Use two different decoders on a JS value. This is nice for extracting
--- | multiple fields from an object.
--- |
--- |     point :: Decoder (Tuple Float Float)
--- |     point =
--- |         object2 Tuple
--- |           ("x" := float)
--- |           ("y" := float)
+-- | > Use two different decoders on a JS value. This is nice for extracting
+-- | > multiple fields from an object.
+-- | >
+-- | >     point :: Decoder (Tuple Float Float)
+-- | >     point =
+-- | >         object2 Tuple
+-- | >           ("x" := float)
+-- | >           ("y" := float)
 -- |
 -- | Equivalent to Purescript's `lift2`.
 -- |
@@ -629,17 +804,17 @@ object2 :: ∀ a b value. (a -> b -> value) -> Decoder a -> Decoder b -> Decoder
 object2 = lift2
 
 
--- | Use three different decoders on a JS value. This is nice for extracting
--- | multiple fields from an object.
--- |
--- |     type Job = { name :: String, id :: Int, completed :: Bool }
--- |
--- |     job :: Decoder Job
--- |     job =
--- |         object3 Job
--- |           ("name" := string)
--- |           ("id" := int)
--- |           ("completed" := bool)
+-- | > Use three different decoders on a JS value. This is nice for extracting
+-- | > multiple fields from an object.
+-- | >
+-- | >     type Job = { name :: String, id :: Int, completed :: Bool }
+-- | >
+-- | >     job :: Decoder Job
+-- | >     job =
+-- | >         object3 Job
+-- | >           ("name" := string)
+-- | >           ("id" := int)
+-- | >           ("completed" := bool)
 -- |
 -- | Equivalent to Purescript's `lift3`.
 -- |
@@ -707,14 +882,14 @@ object8 :: ∀ a b c d e f g h value. (a -> b -> c -> d -> e -> f -> g -> h -> v
 object8 = map8
 
 
--- | Decode a JSON object into an Elm `List` of pairs.
--- |
--- |     decodeString (keyValuePairs int) "{ \"alice\": 42, \"bob\": 99 }"
--- |       == [("alice", 42), ("bob", 99)]
+-- | > Decode a JSON object into an Elm `List` of pairs.
+-- | >
+-- | >     decodeString (keyValuePairs int) "{ \"alice\": 42, \"bob\": 99 }"
+-- | >       == [("alice", 42), ("bob", 99)]
 -- |
 -- | The container for the return type is polymorphic in order to accommodate `List` or `Array`, among others.
 -- |
--- | Does not work with `equalDecoders` yet, but should be fixable.
+-- | Does not work with `equalDecoders` yet, but this should be fixable.
 keyValuePairs :: ∀ f a. Monoid (f (Tuple String a)) => Applicative f => Decoder a -> Decoder (f (Tuple String a))
 keyValuePairs decoder = do
     arr <-
@@ -740,10 +915,10 @@ keys val = toResult $ DF.fail $ TypeMismatch "object" (typeOf val)
 foreign import unsafeKeys :: Foreign -> Array String
 
 
--- | Decode a JSON object into an Elm `Dict`.
--- |
--- |     decodeString (dict int) "{ \"alice\": 42, \"bob\": 99 }"
--- |       == Dict.fromList [("alice", 42), ("bob", 99)]
+-- | > Decode a JSON object into an Elm `Dict`.
+-- | >
+-- | >     decodeString (dict int) "{ \"alice\": 42, \"bob\": 99 }"
+-- | >       == Dict.fromList [("alice", 42), ("bob", 99)]
 -- |
 -- | Does not work with `equalDecoders` yet, but should be fixable.
 dict :: ∀ a. Decoder a -> Decoder (Dict String a)
@@ -770,78 +945,81 @@ fromForeign :: ∀ a. (Foreign -> F a) -> Decoder a
 fromForeign = FromForeign
 
 
--- | Decode a JSON string into an Elm `String`.
--- |
--- |     decodeString string "true"              == Err ...
--- |     decodeString string "42"                == Err ...
--- |     decodeString string "3.14"              == Err ...
--- |     decodeString string "\"hello\""         == Ok "hello"
--- |     decodeString string "{ \"hello\": 42 }" == Err ...
+-- | > Decode a JSON string into an Elm `String`.
+-- | >
+-- | >     decodeString string "true"              == Err ...
+-- | >     decodeString string "42"                == Err ...
+-- | >     decodeString string "3.14"              == Err ...
+-- | >     decodeString string "\"hello\""         == Ok "hello"
+-- | >     decodeString string "{ \"hello\": 42 }" == Err ...
 -- |
 -- | Works with `equalDecoders`
 string :: Decoder String
 string = fromForeign readString
 
 
--- | Decode a JSON number into an Elm `Float`.
--- |
--- |     decodeString float "true"              == Err ..
--- |     decodeString float "42"                == Ok 42
--- |     decodeString float "3.14"              == Ok 3.14
--- |     decodeString float "\"hello\""         == Err ...
--- |     decodeString float "{ \"hello\": 42 }" == Err ...
+-- | > Decode a JSON number into an Elm `Float`.
+-- | >
+-- | >     decodeString float "true"              == Err ..
+-- | >     decodeString float "42"                == Ok 42
+-- | >     decodeString float "3.14"              == Ok 3.14
+-- | >     decodeString float "\"hello\""         == Err ...
+-- | >     decodeString float "{ \"hello\": 42 }" == Err ...
 -- |
 -- | Works with `equalDecoders`
 float :: Decoder Float
 float = fromForeign readNumber
 
 
--- | Decode a JSON number into an Elm `Int`.
--- |
--- |     decodeString int "true"              == Err ...
--- |     decodeString int "42"                == Ok 42
--- |     decodeString int "3.14"              == Err ...
--- |     decodeString int "\"hello\""         == Err ...
--- |     decodeString int "{ \"hello\": 42 }" == Err ...
+-- | > Decode a JSON number into an Elm `Int`.
+-- | >
+-- | >     decodeString int "true"              == Err ...
+-- | >     decodeString int "42"                == Ok 42
+-- | >     decodeString int "3.14"              == Err ...
+-- | >     decodeString int "\"hello\""         == Err ...
+-- | >     decodeString int "{ \"hello\": 42 }" == Err ...
 -- |
 -- | Works with `equalDecoders`
 int :: Decoder Int
 int = fromForeign readInt
 
 
--- | Decode a JSON boolean into an Elm `Bool`.
--- |
--- |     decodeString bool "true"              == Ok True
--- |     decodeString bool "42"                == Err ...
--- |     decodeString bool "3.14"              == Err ...
--- |     decodeString bool "\"hello\""         == Err ...
--- |     decodeString bool "{ \"hello\": 42 }" == Err ...
+-- | > Decode a JSON boolean into an Elm `Bool`.
+-- | >
+-- | >     decodeString bool "true"              == Ok True
+-- | >     decodeString bool "42"                == Err ...
+-- | >     decodeString bool "3.14"              == Err ...
+-- | >     decodeString bool "\"hello\""         == Err ...
+-- | >     decodeString bool "{ \"hello\": 42 }" == Err ...
 -- |
 -- | Works with `equalDecoders`
 bool :: Decoder Bool
 bool = fromForeign readBoolean
 
 
--- | Decode a JSON array into an Elm `List`.
--- |
--- |     decodeString (list int) "[1,2,3]"       == Ok [1,2,3]
--- |     decodeString (list bool) "[true,false]" == Ok [True,False]
+-- | > Decode a JSON array into an Elm `List`.
+-- | >
+-- | >     decodeString (list int) "[1,2,3]"       == Ok [1,2,3]
+-- | >     decodeString (list bool) "[true,false]" == Ok [True,False]
 -- |
 -- | Preserves equality-checking for the input with `equalDecoders`
+-- |
+-- | You can also use `unfoldable` to decode into any container type that has
+-- | an `Unfoldable` instance.
 list :: ∀ a. Decoder a -> Decoder (List a)
 list = unfoldable
 
 
--- | Decode a JSON array into an Elm `Array`.
--- |
--- |     decodeString (array int) "[1,2,3]"       == Ok (Array.fromList [1,2,3])
--- |     decodeString (array bool) "[true,false]" == Ok (Array.fromList [True,False])
--- |
--- | The return type is polymorphic to accommodate `Array` and `Elm.Array`,
--- | among others.
+-- | > Decode a JSON array into an Elm `Array`.
+-- | >
+-- | >     decodeString (array int) "[1,2,3]"       == Ok (Array.fromList [1,2,3])
+-- | >     decodeString (array bool) "[true,false]" == Ok (Array.fromList [True,False])
 -- |
 -- | Preserves equality-checking for the input with `equalDecoders`
-array :: ∀ a. Decoder a -> Decoder (ElmArray.Array a)
+-- |
+-- | You can also use `unfoldable` to decode into any container type that has
+-- | an `Unfoldable` instance.
+array :: ∀ a. Decoder a -> Decoder (Elm.Array.Array a)
 array = unfoldable
 
 
@@ -866,33 +1044,33 @@ unfoldable decoder =
             }
 
 
--- | Decode a `null` value into some Elm value.
--- |
--- |     decodeString (null False) "null" == Ok False
--- |     decodeString (null 42) "null"    == Ok 42
--- |     decodeString (null 42) "42"      == Err ..
--- |     decodeString (null 42) "false"   == Err ..
--- |
--- | So if you ever see a `null`, this will return whatever value you specified.
+-- | > Decode a `null` value into some Elm value.
+-- | >
+-- | >     decodeString (null False) "null" == Ok False
+-- | >     decodeString (null 42) "null"    == Ok 42
+-- | >     decodeString (null 42) "42"      == Err ..
+-- | >     decodeString (null 42) "false"   == Err ..
+-- | >
+-- | > So if you ever see a `null`, this will return whatever value you specified.
 -- |
 -- | Works with `equalDecoders`
 null :: ∀ a. Eq a => a -> Decoder a
 null = Null (Just eq)
 
 
--- | LIke `null`, but for cases where your default value does not have an `Eq`
+-- | Like `null`, but for cases where your default value does not have an `Eq`
 -- | instance. Use `null` where you can, because it will make `equalDecoders`
 -- | more reliable.
 null_ :: ∀ a. a -> Decoder a
 null_ = Null Nothing
 
 
--- | Decode a nullable JSON value into an Elm value.
--- |
--- |     decodeString (nullable int) "13"    == Ok (Just 13)
--- |     decodeString (nullable int) "42"    == Ok (Just 42)
--- |     decodeString (nullable int) "null"  == Ok Nothing
--- |     decodeString (nullable int) "true"  == Err ..
+-- | > Decode a nullable JSON value into an Elm value.
+-- | >
+-- | >     decodeString (nullable int) "13"    == Ok (Just 13)
+-- | >     decodeString (nullable int) "42"    == Ok (Just 42)
+-- | >     decodeString (nullable int) "null"  == Ok Nothing
+-- | >     decodeString (nullable int) "true"  == Err ..
 -- |
 -- | This function was added in Elm 0.18.
 -- |
@@ -903,24 +1081,24 @@ nullable decoder =
     null_ Nothing <|> map Just decoder
 
 
--- | Helpful for dealing with optional fields. Here are a few slightly different
--- | examples:
--- |
--- |     json = """{ "name": "tom", "age": 42 }"""
--- |
--- |     decodeString (maybe (field "age"    int  )) json == Ok (Just 42)
--- |     decodeString (maybe (field "name"   int  )) json == Ok Nothing
--- |     decodeString (maybe (field "height" float)) json == Ok Nothing
--- |
--- |     decodeString (field "age"    (maybe int  )) json == Ok (Just 42)
--- |     decodeString (field "name"   (maybe int  )) json == Ok Nothing
--- |     decodeString (field "height" (maybe float)) json == Err ...
--- |
--- | Notice the last example! It is saying we *must* have a field named `height` and
--- | the content *may* be a float. There is no `height` field, so the decoder fails.
--- |
--- | Point is, `maybe` will make exactly what it contains conditional. For optional
--- | fields, this means you probably want it *outside* a use of `field` or `at`.
+-- | > Helpful for dealing with optional fields. Here are a few slightly different
+-- | > examples:
+-- | >
+-- | >     json = """{ "name": "tom", "age": 42 }"""
+-- | >
+-- | >     decodeString (maybe (field "age"    int  )) json == Ok (Just 42)
+-- | >     decodeString (maybe (field "name"   int  )) json == Ok Nothing
+-- | >     decodeString (maybe (field "height" float)) json == Ok Nothing
+-- | >
+-- | >     decodeString (field "age"    (maybe int  )) json == Ok (Just 42)
+-- | >     decodeString (field "name"   (maybe int  )) json == Ok Nothing
+-- | >     decodeString (field "height" (maybe float)) json == Err ...
+-- | >
+-- | > Notice the last example! It is saying we *must* have a field named `height` and
+-- | > the content *may* be a float. There is no `height` field, so the decoder fails.
+-- | >
+-- | > Point is, `maybe` will make exactly what it contains conditional. For optional
+-- | > fields, this means you probably want it *outside* a use of `field` or `at`.
 -- |
 -- | `equalDecoders` will consider the results of this function to be equal if
 -- | the provided decoder is equal ... that is, `maybe` is equal-preserving.
@@ -929,10 +1107,10 @@ maybe decoder =
     map Just decoder <|> succeed_ Nothing
 
 
--- | Do not do anything with a JSON value, just bring it into Elm as a `Value`.
--- | This can be useful if you have particularly crazy data that you would like to
--- | deal with later. Or if you are going to send it out a port and do not care
--- | about its structure.
+-- | > Do not do anything with a JSON value, just bring it into Elm as a `Value`.
+-- | > This can be useful if you have particularly crazy data that you would like to
+-- | > deal with later. Or if you are going to send it out a port and do not care
+-- | > about its structure.
 -- |
 -- | Works with `equalDecoders`
 value :: Decoder Value
@@ -949,7 +1127,9 @@ fromResult =
             fail err
 
 
--- | Create a custom decoder that may do some fancy computation.
+-- | > Create a custom decoder that may do some fancy computation.
+-- |
+-- | This function was removed in Elm 0.18.
 -- |
 -- | `equalDecoders` will consider the resulting decoders equal if the input
 -- | decoders are equal, and the provided functions in each case are
@@ -959,31 +1139,31 @@ customDecoder decoder func =
     func <$> decoder >>= fromResult
 
 
--- | Sometimes you have JSON with recursive structure, like nested comments.
--- | You can use `lazy` to make sure your decoder unrolls lazily.
--- |
--- |     type alias Comment =
--- |       { message : String
--- |       , responses : Responses
--- |       }
--- |
--- |     type Responses = Responses (List Comment)
--- |
--- |     comment : Decoder Comment
--- |     comment =
--- |       map2 Comment
--- |         (field "message" string)
--- |         (field "responses" (map Responses (list (lazy (\_ -> comment)))))
--- |
--- | If we had said `list comment` instead, we would start expanding the value
--- | infinitely. What is a `comment`? It is a decoder for objects where the
--- | `responses` field contains comments. What is a `comment` though? Etc.
--- |
--- | By using `list (lazy (\_ -> comment))` we make sure the decoder only expands
--- | to be as deep as the JSON we are given. You can read more about recursive data
--- | structures [here][].
--- |
--- | [here]: https://github.com/elm-lang/elm-compiler/blob/master/hints/recursive-alias.md
+-- | > Sometimes you have JSON with recursive structure, like nested comments.
+-- | > You can use `lazy` to make sure your decoder unrolls lazily.
+-- | >
+-- | >     type alias Comment =
+-- | >       { message : String
+-- | >       , responses : Responses
+-- | >       }
+-- | >
+-- | >     type Responses = Responses (List Comment)
+-- | >
+-- | >     comment : Decoder Comment
+-- | >     comment =
+-- | >       map2 Comment
+-- | >         (field "message" string)
+-- | >         (field "responses" (map Responses (list (lazy (\_ -> comment)))))
+-- | >
+-- | > If we had said `list comment` instead, we would start expanding the value
+-- | > infinitely. What is a `comment`? It is a decoder for objects where the
+-- | > `responses` field contains comments. What is a `comment` though? Etc.
+-- | >
+-- | > By using `list (lazy (\_ -> comment))` we make sure the decoder only expands
+-- | > to be as deep as the JSON we are given. You can read more about recursive data
+-- | > structures [here][].
+-- | >
+-- | > [here]: https://github.com/elm-lang/elm-compiler/blob/master/hints/recursive-alias.md
 -- |
 -- | This function was added in Elm 0.18.
 -- |
@@ -995,9 +1175,9 @@ lazy :: ∀ a. (Unit -> Decoder a) -> Decoder a
 lazy = bind (pure unit)
 
 
--- | Ignore the JSON and make the decoder fail. This is handy when used with
--- | `oneOf` or `andThen` where you want to give a custom error message in some
--- | case.
+-- | > Ignore the JSON and make the decoder fail. This is handy when used with
+-- | > `oneOf` or `andThen` where you want to give a custom error message in some
+-- | > case.
 -- |
 -- | `equalDecoders` considers two `fail` decoders to be equal if they have the
 -- | same message.
@@ -1005,13 +1185,13 @@ fail :: ∀ a. String -> Decoder a
 fail = Fail
 
 
--- | Ignore the JSON and produce a certain Elm value.
--- |
--- |     decodeString (succeed 42) "true"    == Ok 42
--- |     decodeString (succeed 42) "[1,2,3]" == Ok 42
--- |     decodeString (succeed 42) "hello"   == Err ... -- this is not a valid JSON string
--- |
--- | This is handy when used with `oneOf` or `andThen`.
+-- | > Ignore the JSON and produce a certain Elm value.
+-- | >
+-- | >     decodeString (succeed 42) "true"    == Ok 42
+-- | >     decodeString (succeed 42) "[1,2,3]" == Ok 42
+-- | >     decodeString (succeed 42) "hello"   == Err ... -- this is not a valid JSON string
+-- | >
+-- | > This is handy when used with `oneOf` or `andThen`.
 -- |
 -- | Works well with `equalDecoders`.
 succeed :: ∀ a. Eq a => a -> Decoder a
@@ -1028,18 +1208,18 @@ succeed_ = Succeed Nothing
 
 -- TUPLES
 
--- | Handle an array with exactly one element.
--- |
--- |     extractString :: Decoder String
--- |     extractString =
--- |         tuple1 identity string
--- |
--- |     authorship :: Decoder String
--- |     authorship =
--- |         oneOf
--- |           [ tuple1 (\author -> "Author: " <> author) string
--- |           , list string |> map (\authors -> "Co-authors: " <> String.join ", " authors)
--- |           ]
+-- | > Handle an array with exactly one element.
+-- | >
+-- | >     extractString :: Decoder String
+-- | >     extractString =
+-- | >         tuple1 identity string
+-- | >
+-- | >     authorship :: Decoder String
+-- | >     authorship =
+-- | >         oneOf
+-- | >           [ tuple1 (\author -> "Author: " <> author) string
+-- | >           , list string |> map (\authors -> "Co-authors: " <> String.join ", " authors)
+-- | >           ]
 -- |
 -- | This function was removed in Elm 0.18.
 -- |
@@ -1050,20 +1230,20 @@ tuple1 func d0 = do
     func <$> index 0 d0
 
 
--- | Handle an array with exactly two elements. Useful for points and simple
--- | pairs.
--- |
--- |     -- [3,4] or [0,0]
--- |     point :: Decoder (Tuple Float Float)
--- |     point =
--- |         tuple2 Tuple float float
--- |
--- |     -- ["John","Doe"] or ["Hermann","Hesse"]
--- |     name :: Decoder Name
--- |     name =
--- |         tuple2 Name string string
--- |
--- |     type Name = { first :: String, last :: String }
+-- | > Handle an array with exactly two elements. Useful for points and simple
+-- | > pairs.
+-- | >
+-- | >     -- [3,4] or [0,0]
+-- | >     point :: Decoder (Tuple Float Float)
+-- | >     point =
+-- | >         tuple2 Tuple float float
+-- | >
+-- | >     -- ["John","Doe"] or ["Hermann","Hesse"]
+-- | >     name :: Decoder Name
+-- | >     name =
+-- | >         tuple2 Name string string
+-- | >
+-- | >     type Name = { first :: String, last :: String }
 -- |
 -- | This function was removed in Elm 0.18.
 -- |
@@ -1078,7 +1258,7 @@ tuple2 func d0 d1 = do
     pure $ func v0 v1
 
 
--- | Handle an array with exactly three elements.
+-- | > Handle an array with exactly three elements.
 -- |
 -- | This function was removed in Elm 0.18.
 -- |

--- a/src/Elm/Json/Decode.purs
+++ b/src/Elm/Json/Decode.purs
@@ -354,6 +354,8 @@ instance functorDecoder :: Functor Decoder where
     -- | Works with `equalDecoders` so long as the supplied functions are
     -- | referentially equal.
     map func decoder =
+        -- We know what the answer will be up-front for certain mapping
+        -- operations, so we don't need to defer all of them.
         case decoder of
             Empty ->
                 Empty
@@ -367,6 +369,9 @@ instance functorDecoder :: Functor Decoder where
 
 instance altDecoder :: Alt Decoder where
     -- | Works with `equalDecoders`
+    --
+    -- We can apply the `Plus` laws immediately (but we also consider them in
+    -- `decodeValue` and `equalDecoders`, just in case).
     alt Empty b = b
     alt a Empty = a
     alt a b = OneOf a b

--- a/test/Test/Elm/Json.purs
+++ b/test/Test/Elm/Json.purs
@@ -6,6 +6,7 @@ import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Exception (EXCEPTION)
 import Control.Monad.Eff.Random (RANDOM)
 import Control.Plus (class Plus)
+import Data.Array (toUnfoldable)
 import Data.Foldable (traverse_)
 import Data.Foreign (toForeign)
 import Data.Generic (class Generic, gEq, gShow)
@@ -449,6 +450,30 @@ tests = suite "Json" do
                 ==> Nothing
             ]
 
+    test "list" do
+        let decoder = list int
+        traverse_ (check decoder)
+            [ """ [ 7, 12, 13 ] """ ==> Just (7 : 12 : 13 : Nil)
+            , """ 7 """ ==> Nothing
+            , """ [ "12" ] """ ==> Nothing
+            ]
+
+    test "array" do
+        let decoder = array int
+        traverse_ (check decoder)
+            [ """ [ 7, 12, 13 ] """ ==> Just (toUnfoldable [7, 12, 13])
+            , """ 7 """ ==> Nothing
+            , """ [ "12" ] """ ==> Nothing
+            ]
+
+    test "unfoldable" do
+        let decoder = unfoldable int
+        traverse_ (check decoder)
+            [ """ [ 7, 12, 13 ] """ ==> Just [7, 12, 13]
+            , """ 7 """ ==> Nothing
+            , """ [ "12" ] """ ==> Nothing
+            ]
+
     test "maybe" do
         let
             decoder =
@@ -699,15 +724,15 @@ tests = suite "Json" do
             assert "equal" $ object3 makeJob decoder1 decoder2 decoder3 `equalDecoders` object3 makeJob decoder1 decoder2 decoder3
 
         test "list" do
-            -- assert "equal" $ list (succeed 17) `equalDecoders` list (succeed 17)
+            assert "equal" $ list (succeed 17) `equalDecoders` list (succeed 17)
             assertFalse "unequal" $ list (succeed 17) `equalDecoders` list (succeed 18)
 
         test "array" do
-            -- assert "equal" $ array (succeed 17) `equalDecoders` array (succeed 17)
+            assert "equal" $ array (succeed 17) `equalDecoders` array (succeed 17)
             assertFalse "unequal" $ array (succeed 17) `equalDecoders` array (succeed 18)
 
         test "unfoldable" do
-           -- assert "equal" $ unfoldable (succeed 17) :: Decoder (Array Int) `equalDecoders` unfoldable (succeed 17)
+           assert "equal" $ unfoldable (succeed 17) :: Decoder (Array Int) `equalDecoders` unfoldable (succeed 17)
            assertFalse "unequal" $ unfoldable (succeed 17) :: Decoder (Array Int) `equalDecoders` unfoldable (succeed 18)
 
         test "tuple1" do

--- a/test/Test/Elm/Json.purs
+++ b/test/Test/Elm/Json.purs
@@ -5,6 +5,7 @@ import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Exception (EXCEPTION)
 import Control.Monad.Eff.Random (RANDOM)
+import Control.Plus (class Plus)
 import Data.Foldable (traverse_)
 import Data.Foreign (toForeign)
 import Data.Generic (class Generic, gEq, gShow)
@@ -21,13 +22,14 @@ import Elm.Json.Decode as JD
 import Elm.Json.Encode as JE
 import Elm.Result (Result(..), toMaybe)
 import Math (sqrt)
-import Prelude (class Show, show, class Monad, class Bind, bind, class Eq, (==), class Functor, map, class Apply, apply, class Applicative, pure, flip, negate, discard, (<>), ($), (+), (<<<))
+import Prelude (class Applicative, class Apply, class Bind, class Eq, class Functor, class Monad, class Show, bind, discard, flip, map, negate, pure, show, ($), (+), (<>), (==))
 import Test.QuickCheck.Arbitrary (class Arbitrary, arbitrary)
 import Test.QuickCheck.Laws.Control.Alt (checkAlt)
 import Test.QuickCheck.Laws.Control.Applicative (checkApplicative)
 import Test.QuickCheck.Laws.Control.Apply (checkApply)
 import Test.QuickCheck.Laws.Control.Bind (checkBind)
 import Test.QuickCheck.Laws.Control.Monad (checkMonad)
+import Test.QuickCheck.Laws.Control.Plus (checkPlus)
 import Test.QuickCheck.Laws.Data.Functor (checkFunctor)
 import Test.Unit (TestSuite, Test, suite, test)
 import Test.Unit.Assert (assert, assertFalse, equal)
@@ -716,6 +718,7 @@ tests = suite "Json" do
             checkApplicative proxyDecoder
             checkBind proxyDecoder
             checkMonad proxyDecoder
+            checkPlus proxyDecoder
 
 
 -- We test the laws via a newtype, in order to avoid making spurious
@@ -723,29 +726,12 @@ tests = suite "Json" do
 -- do orphan instances).
 newtype DecoderLaws a = DecoderLaws (JD.Decoder a)
 
-
-instance functorDecoderLaws :: Functor DecoderLaws where
-    map func (DecoderLaws decoder) = DecoderLaws $ map func decoder
-
-
-instance altDecoderLaws :: Alt DecoderLaws where
-    alt (DecoderLaws left) (DecoderLaws right) = DecoderLaws $ alt left right
-
-
-instance applyDecoderLaws :: Apply DecoderLaws where
-    apply (DecoderLaws func) (DecoderLaws decoder) = DecoderLaws $ apply func decoder
-
-
-instance applicativeDecoderLaws :: Applicative DecoderLaws where
-    pure = DecoderLaws <<< pure
-
-
-instance bindDecoderLaws :: Bind DecoderLaws where
-    bind (DecoderLaws decoder) func =
-        DecoderLaws $ bind decoder
-            \a -> case func a of
-                DecoderLaws x -> x
-
+derive newtype instance functorDecoderLaws :: Functor DecoderLaws
+derive newtype instance altDecoderLaws :: Alt DecoderLaws
+derive newtype instance applyDecoderLaws :: Apply DecoderLaws
+derive newtype instance applicativeDecoderLaws :: Applicative DecoderLaws
+derive newtype instance bindDecoderLaws :: Bind DecoderLaws
+derive newtype instance plusDecoderLaws :: Plus DecoderLaws
 
 instance monadDecoderLaws :: Monad DecoderLaws
 

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -41,16 +41,16 @@ main :: Eff
     ) Unit
 main =
     runTest do
-       {- Array.tests
+        Array.tests
         Basics.tests
         BasicsElm.tests
         Bitwise.tests
         Char.tests
         Color.tests
         Date.tests
-        Dict.tests -}
+        Dict.tests
         Json.tests
-    {- List.tests
+        List.tests
         ListElm.tests
         Maybe.tests
         Random.tests
@@ -60,4 +60,4 @@ main =
         String.tests
         Time.tests
         Task.tests
-        Trampoline.tests -}
+        Trampoline.tests

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -41,16 +41,16 @@ main :: Eff
     ) Unit
 main =
     runTest do
-        Array.tests
+       {- Array.tests
         Basics.tests
         BasicsElm.tests
         Bitwise.tests
         Char.tests
         Color.tests
         Date.tests
-        Dict.tests
+        Dict.tests -}
         Json.tests
-        List.tests
+    {- List.tests
         ListElm.tests
         Maybe.tests
         Random.tests
@@ -60,4 +60,4 @@ main =
         String.tests
         Time.tests
         Task.tests
-        Trampoline.tests
+        Trampoline.tests -}


### PR DESCRIPTION
In Elm, a JSON Decoder is, from one point of view, simply a function which takes a `Value` as an input, and produces something as an output. In fact, in implementing `Elm.Json.Decode`, I have been defining it in this way:

    newtype Decoder a = Decoder (Value -> Result String a)

... and it's perfectly possible to implement the Elm decoder API on this basis.

However, that's not how Elm actually implements a decoder -- it creates a kind of DSL, collecting information about how to proceed, and only actually "running" the DSL when needed.

My theory is that Elm does that because it needs to test the equality of decoders -- it has an `equalDecoders` function for this purpose. I believe the reason Elm wants to test the equality of decoders is to be able to test the equality of HTML nodes in the virtual DOM. A decoder is an essential part of various event handlers. Thus, to test whether an event handler has changed, and thus a listener needs to be removed and/or applied, you need to test the equality of the decoder you got in the previous round with the decoder you got in this round. Unless you can determine that the decoders are equal, you'll need to remove the previous listener and add it again, which would be inefficient (at the very least).

Now, if a `Decoder` were just a `Function`, there would be very little you could do to test for equality.

- You can use referential equality, but that is subject to false negatives ... two functions can be equal without being the very same function. (E.g. lambdas that have the same inputs, but are produced on separate occasions).

- Some Javascript implementations will give you the source code of the function as a string if you ask. However, I don't think this is actually reliable as an equality test because you wouldn't necessarily have closed over the same values. (I don't think this affects the referential equality check, since you couldn't have closed over different values if you're referentially equal).

- In theory, you could call the functions on the entire input domain and compare the outputs, but that's only practical in specialized situations. (It would be practical in some situations where the input domain isn't very large).

So, basically you're stuck with referential equality ... the two decoders would be equal if they were the very same function.

What I think the Elm implementation is trying to do is make judging equality slightly more accurate, especially when composing decoders together. If you compose two functions together, the result will not be referentially equal unless you hang onto a reference and use it. However, in the Elm DSL, the composition of two decoders doesn't "forget" the original decoders. So, if the inputs are referentially equal, it's still possible to determine that the composed decoders are equal, even if you don't retain a reference to the composed decoder.

So, what I'm attempting to do on this PR is to be at least as good as Elm is when judging the equality of decoders.







